### PR TITLE
Add InventorySummary document

### DIFF
--- a/lib/gentle/documents/response/inventory_summary_ready.rb
+++ b/lib/gentle/documents/response/inventory_summary_ready.rb
@@ -1,0 +1,40 @@
+module Gentle
+  module Documents
+    module Response
+      class InventorySummaryReady
+        attr_reader :io
+
+        def initialize(options = {})
+          @io = options[:io]
+          @document = Nokogiri::XML::Document.parse(@io)
+        end
+
+        def warehouse
+          @document.root.attributes['Warehouse'].value
+        end
+
+        def inventories
+          @document.root
+            .children
+            .select { |c| c.name == 'Inventory' }
+            .map { |i| Inventory.new(i) }
+        end
+
+        private
+
+        class Inventory < SimpleDelegator
+          def item_number
+            attributes['ItemNumber'].value
+          end
+
+          def quantity_available
+            children
+              .select { |c| c.name == 'ItemStatus' && c.attributes['Status'].value == 'Avail' }
+              .first
+              .attributes['Quantity'].value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gentle/response.rb
+++ b/lib/gentle/response.rb
@@ -1,8 +1,9 @@
 require 'gentle/documents/response/shipment_order_result'
+require 'gentle/documents/response/inventory_summary_ready'
 
 module Gentle
   module Response
-    VALID_RESPONSE_TYPES = %w(ShipmentOrderResult)
+    VALID_RESPONSE_TYPES = %w(ShipmentOrderResult InventorySummaryReady)
 
     def self.valid_type?(type)
       VALID_RESPONSE_TYPES.include?(type)

--- a/spec/fixtures/documents/responses/inventory_summary.xml
+++ b/spec/fixtures/documents/responses/inventory_summary.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<InventorySummary
+  xmlns="http://schemas.quietlogistics.com/V2/InventorySummary.xsd"
+  ClientId="Gentle"
+  BusinessUnit="Gentle"
+  Warehouse="DVN">
+  <Inventory ItemNumber="12345">
+    <ItemStatus Status="Avail" Quantity="5" />
+    <ItemStatus Status="RECEIVED" Quantity="1" />
+    <ItemStatus Status="Alloc" Quantity="1" />
+  </Inventory>
+  <Inventory ItemNumber="12346">
+    <ItemStatus Status="Avail" Quantity="2" />
+  </Inventory>
+</InventorySummary>

--- a/spec/unit/documents/response/inventory_summary_ready_spec.rb
+++ b/spec/unit/documents/response/inventory_summary_ready_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'gentle/documents/response/inventory_summary_ready'
+
+module Gentle
+  module Documents
+    module Response
+      describe "InventorySummaryReady" do
+        include Fixtures
+
+        it "has warehouse name" do
+          document = load_response('inventory_summary')
+          order_result = InventorySummaryReady.new(io: document)
+
+          assert_equal 'DVN', order_result.warehouse
+        end
+
+        describe '#inventories' do
+          it "returns available inventory levels" do
+            document = load_response('inventory_summary')
+            order_result = InventorySummaryReady.new(io: document)
+
+            assert_equal Array, order_result.inventories.class
+            assert_equal ["5", "2"], order_result.inventories.collect(&:quantity_available)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/response_spec.rb
+++ b/spec/unit/response_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'gentle/response'
+
+module Gentle
+  describe Response do
+    describe '.valid_type?' do
+      it 'is valid with ShipmentOrderResult given' do
+        assert Gentle::Response.valid_type?('ShipmentOrderResult')
+      end
+
+      it 'is valid with InventorySummaryReady given' do
+        assert Gentle::Response.valid_type?('InventorySummaryReady')
+      end
+
+      it 'is invalid with anything else given' do
+        refute Gentle::Response.valid_type?('AnythingElse')
+      end
+    end
+  end
+end


### PR DESCRIPTION
The QL API returns InventorySummary documents with Blackboard if set up by the client or an InventorySummaryRequest message was sent upfront.

Unfortunately and contrary to their documentation the DocumentType returned inside the EventMessage is InventorySummaryReady. So, that is why the document is called InventorySummaryReady instead of InventorySummary (although the XMl still is a InventorySummary).