### PR TITLE
Add namespace accessor to inventory summary response

### DIFF
--- a/lib/gentle/documents/response/inventory_summary_ready.rb
+++ b/lib/gentle/documents/response/inventory_summary_ready.rb
@@ -9,6 +9,10 @@ module Gentle
           @document = Nokogiri::XML::Document.parse(@io)
         end
 
+        def namespace
+          @namespace ||= @document.collect_namespaces['xmlns']
+        end
+
         def warehouse
           @document.root.attributes['Warehouse'].value
         end

--- a/spec/unit/documents/response/inventory_summary_ready_spec.rb
+++ b/spec/unit/documents/response/inventory_summary_ready_spec.rb
@@ -14,6 +14,13 @@ module Gentle
           assert_equal 'DVN', order_result.warehouse
         end
 
+        it "has correct XML namespace" do
+          document = load_response('inventory_summary')
+          order_result = InventorySummaryReady.new(io: document)
+
+          assert_equal 'http://schemas.quietlogistics.com/V2/InventorySummary.xsd', order_result.namespace
+        end
+
         describe '#inventories' do
           it "returns available inventory levels" do
             document = load_response('inventory_summary')


### PR DESCRIPTION
The ship_quiet_logistics gem uses this to call the correct handler for
that document.